### PR TITLE
fix: 분석 결과 페이지 lottie 배경 바닥 고정

### DIFF
--- a/src/domains/Analysis/components/DataFetchComponents.tsx
+++ b/src/domains/Analysis/components/DataFetchComponents.tsx
@@ -17,7 +17,7 @@ export function GrowthPrediectionFetch({
 
   useEffect(() => {
     if (isSuccess) {
-      navigate('/result');
+      setTimeout(() => navigate('/result'), 2000);
     }
   }, [isSuccess]);
 

--- a/src/pages/Result.tsx
+++ b/src/pages/Result.tsx
@@ -1,3 +1,4 @@
+import { RefObject, useEffect, useRef } from 'react';
 import useStrategyStore from '@/app/store/useStrategyStore';
 import analysis from '@/assets/result/analaysis.json';
 import { ResultInteraction } from '@/domains/Results/components';
@@ -6,9 +7,14 @@ import { LottieAnimation } from '@/shared/ui';
 
 export default function Result() {
   const channelName = useStrategyStore((store) => store.channelName);
+  const bottomRef: RefObject<HTMLDivElement> = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ block: 'end' });
+  }, []);
+
   return (
     <div className={'h-screen'}>
-      <div className={'overflow-hidden relative  h-full z-10'}>
+      <div className={'sticky bottom-0 overflow-hidden z-10 h-full'}>
         <LottieAnimation animationData={analysis} />
       </div>
       <div className={'flex justify-center'}>
@@ -19,6 +25,7 @@ export default function Result() {
         text={'다음'}
         buttonType={'large-filled-button'}
       />
+      <div ref={bottomRef} />
     </div>
   );
 }

--- a/src/pages/UserInfo.tsx
+++ b/src/pages/UserInfo.tsx
@@ -146,6 +146,7 @@ function UserInfo() {
           <UserInformationProfiles />
           <div className={'mt-[10px]'}>
             <ChannelCommonCard
+              isLogin
               header={
                 <LocationMove
                   location={`https://www.youtube.com/@${data.result.channelId}`}


### PR DESCRIPTION
## 이슈 번호

## 작업한 목록을 작성해 주세요

- 분석 결과 페이지의 lottie 배경이 로딩시에 바닥에 고정 되지 않은 것을 완전히 수정했습니다.
- 사용자 정보 페이지 사용자 프로필 ui 수정했습니다.

## 스크린샷

## pr 포인트나 궁금한 점을 작성해 주세요